### PR TITLE
add core-linux-helpers images

### DIFF
--- a/.github/workflows/core-linux-helpers.yml
+++ b/.github/workflows/core-linux-helpers.yml
@@ -1,0 +1,84 @@
+name: Core Linux Helpers
+
+on:
+  workflow_dispatch:
+    inputs:
+      flavors:
+        description: "List of flavors to build"
+        default: '["x86", "x86_64", "arm", "arm64", "mips", "mipsel", "mips64", "mips64el"]'
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  build-base:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and cache base image
+        uses: docker/build-push-action@v5
+        with:
+          context: core-linux-helpers
+          file: core-linux-helpers/Dockerfile
+          target: base
+          push: false
+          load: true
+          tags: base:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+      - name: Build and cache android image
+        uses: docker/build-push-action@v5
+        with:
+          context: core-linux-helpers
+          file: core-linux-helpers/Dockerfile
+          target: android
+          push: false
+          load: true
+          tags: android:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  core-linux-helpers:
+    needs: build-base
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        flavor: ${{ fromJSON(github.event.inputs.flavors) }}
+      fail-fast: false
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/core-linux-helpers-${{ matrix.flavor }}
+          tags: type=raw,value=latest,enable={{ is_default_branch }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: core-linux-helpers
+          file: core-linux-helpers/Dockerfile
+          target: ${{ matrix.flavor }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/core-linux-helpers/Dockerfile
+++ b/core-linux-helpers/Dockerfile
@@ -1,0 +1,44 @@
+FROM ubuntu:22.04 AS base
+COPY scripts/install-shared-packages.sh /tmp
+COPY scripts/install-platform-packages.sh /tmp
+RUN /tmp/install-shared-packages.sh
+
+FROM base AS android
+# Download and install the Android NDK and delete the downloaded archive so
+# it doesn't take up space in the image layer.
+RUN curl -L https://dl.google.com/android/repository/android-ndk-r25c-linux.zip -o android-ndk-r25c-linux.zip \
+    && unzip android-ndk-r25c-linux.zip -d /opt \
+    && rm android-ndk-r25c-linux.zip
+ENV ANDROID_NDK_ROOT=/opt/android-ndk-r25c
+
+FROM android AS arm64
+ENV XTOOLS_HOST=android-arm64
+RUN /tmp/install-platform-packages.sh g++-aarch64-linux-gnu
+
+FROM android AS arm
+ENV XTOOLS_HOST=android-arm
+RUN /tmp/install-platform-packages.sh g++-arm-linux-gnueabi
+
+FROM base AS mips
+ENV XTOOLS_HOST=mips-linux-gnu
+RUN /tmp/install-platform-packages.sh g++-$XTOOLS_HOST
+
+FROM base AS mips64
+ENV XTOOLS_HOST=mips64-linux-gnuabi64
+RUN /tmp/install-platform-packages.sh g++-$XTOOLS_HOST
+
+FROM base AS mipsel
+ENV XTOOLS_HOST=mipsel-linux-gnu
+RUN /tmp/install-platform-packages.sh g++-$XTOOLS_HOST
+
+FROM base AS mips64el
+ENV XTOOLS_HOST=mips64el-linux-gnuabi64
+RUN /tmp/install-platform-packages.sh g++-$XTOOLS_HOST
+
+FROM base AS x86
+ENV XTOOLS_HOST=i686-linux-gnu
+RUN /tmp/install-platform-packages.sh gcc-multilib lib32stdc++-11-dev
+
+FROM base AS x86_64
+ENV XTOOLS_HOST=x86_64-linux-gnu
+RUN /tmp/install-platform-packages.sh g++-x86-64-linux-gnu

--- a/core-linux-helpers/scripts/install-platform-packages.sh
+++ b/core-linux-helpers/scripts/install-platform-packages.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -ex
+
+apt-get install -y $@
+
+rm -rf \
+    ~/.npm \
+    /var/lib/apt/lists/* \
+    /tmp/install-shared-packages.sh \
+    /tmp/install-platform-packages.sh

--- a/core-linux-helpers/scripts/install-shared-packages.sh
+++ b/core-linux-helpers/scripts/install-shared-packages.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+set -ex
+
+export DEBIAN_FRONTEND=noninteractive
+
+apt-get update
+apt-get install -y \
+    awscli \
+    bison \
+    curl \
+    file \
+    flex \
+    git \
+    gperf \
+    make \
+    ninja-build \
+    pip \
+    pkg-config \
+    python-is-python3 \
+    unzip \
+    valac
+
+curl -fsSL https://deb.nodesource.com/setup_20.x | bash -
+apt-get install -y nodejs
+
+npm install -g cloudflare-cli


### PR DESCRIPTION
These images will be used by the frida-core CI to build (reproducibly) the binary linux helpers that are used as part of injection.